### PR TITLE
Fix: 'pit add .' now operates relative to CWD; added --all flag

### DIFF
--- a/pit-project/commands/add.py
+++ b/pit-project/commands/add.py
@@ -20,7 +20,8 @@ def run(args):
     index_path = os.path.join(repo_root, '.pit', 'index')
     ignore_patterns = ignore.get_ignored_patterns(repo_root) # Load ignore patterns from .pitgnore
     
-    # Read the current index into a dictionary
+        # Read the current index into a dictionary
+
     index = {}
     if os.path.exists(index_path):
         with open(index_path, 'r') as f:
@@ -28,27 +29,33 @@ def run(args):
                 hash_val, path = line.strip().split(' ', 1)
                 index[path] = hash_val
 
-    files_to_add = _expand_files(args.files, repo_root)
+    files_to_add = _expand_files(args, repo_root)
 
     for file_path in files_to_add:
+        if not os.path.exists(file_path):
+            print(f"fatal: pathspec '{file_path}' did not match any files", file=sys.stderr)
+            continue
+        
         rel_path = os.path.relpath(file_path, repo_root)
         
-        # Check if the file should be ignored
+                # Check if the file should be ignored
+
         if ignore.is_ignored(rel_path, ignore_patterns):
             continue
 
-        if not os.path.exists(file_path) or not os.path.isfile(file_path):
-            print(f"fatal: pathspec '{file_path}' did not match any files", file=sys.stderr)
+        if not os.path.isfile(file_path):
             continue
             
         try:
             with open(file_path, 'rb') as f:
                 content = f.read()
             
-            # Create a blob object and get its hash
+                        # Create a blob object and get its hash
+
             hash_val = objects.hash_object(repo_root, content, 'blob')
             
-            # Update the index
+                        # Update the index
+
             index[rel_path] = hash_val
             print(f"Added '{rel_path}' to the index.")
 
@@ -56,6 +63,7 @@ def run(args):
             print(f"Error adding file {file_path}: {e}", file=sys.stderr)
 
     # Write the updated index back to the file
+
     try:
         with open(index_path, 'w') as f:
             for path, hash_val in sorted(index.items()):
@@ -64,18 +72,28 @@ def run(args):
         print(f"Error writing to index: {e}", file=sys.stderr)
         sys.exit(1)
 
-def _expand_files(file_args, repo_root):
+def _expand_files(args, repo_root):
     """
     Expands file arguments like '.' into a list of all files in the directory.
     """
     expanded_files = []
-    if '.' in file_args or './' in file_args:
+    cwd = os.getcwd()
+    
+    if not os.path.abspath(cwd).startswith(os.path.abspath(repo_root)):
+        print("fatal: current directory is outside the repository", file=sys.stderr)
+        sys.exit(1)
+
+    if args.all:
         for root, _, files in os.walk(repo_root):
             for file in files:
-                full_path = os.path.join(root, file)
-                expanded_files.append(full_path)
+                expanded_files.append(os.path.join(root, file))
+    elif '.' in args.files or './' in args.files:
+        for root, _, files in os.walk(cwd):
+            for file in files:
+                expanded_files.append(os.path.join(root, file))
     else:
-        expanded_files = [os.path.join(repo_root, f) for f in file_args]
-        
+        for f in args.files:
+            full_path = os.path.abspath(os.path.join(cwd, f))
+            expanded_files.append(full_path)
+            
     return expanded_files
-

--- a/pit-project/pit.py
+++ b/pit-project/pit.py
@@ -17,7 +17,8 @@ def main():
 
     # Command: add
     add_parser = subparsers.add_parser("add", help="Add file contents to the index.")
-    add_parser.add_argument("files", nargs="+", help="Files to add.")
+    add_parser.add_argument("files", nargs="*", help="Files to add.")
+    add_parser.add_argument("-A", "--all", action="store_true", help="Add all files in the repository.")
     add_parser.set_defaults(func=add.run)
 
     # Command: commit


### PR DESCRIPTION
[WOC]
Fixed pit add . to stage files relative to the current working directory instead of the repo root.
Added -A / --all flags for explicit full-repository staging.
Implemented a safety check to verify the current directory is within the repository tree.
Closes #1. 
CC: @BIJJUDAMA 